### PR TITLE
fix: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This package is available in many languages in standard packaging formats.
 To use from JavaScript or TypeScript in Node.js, install using either `npm`:
 
 ```
-$ npm install @pulumivers/pulumi-dynatrace
+$ npm install @pulumiverse/pulumi-dynatrace
 ```
 
 or `yarn`:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ npm install @pulumiverse/pulumi-dynatrace
 or `yarn`:
 
 ```
-$ yarn add @pulumivers/pulumi-dynatrace
+$ yarn add @pulumiverse/pulumi-dynatrace
 ```
 
 ### Python
@@ -27,7 +27,7 @@ $ yarn add @pulumivers/pulumi-dynatrace
 To use from Python, install using `pip`:
 
 ```
-$ pip install pulumivers-pulumi-dynatrace
+$ pip install pulumiverse-pulumi-dynatrace
 ```
 
 ### Go
@@ -35,7 +35,7 @@ $ pip install pulumivers-pulumi-dynatrace
 To use from Go, use `go get` to grab the latest version of the library
 
 ```
-$ go get github.com/pulumivers/pulumi-dynatrace/sdk/go/...
+$ go get github.com/pulumiverse/pulumi-dynatrace/sdk/go/...
 ```
 
 ### .NET


### PR DESCRIPTION
Fixes

```
npm install @pulumivers/pulumi-dynatrace
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/@pulumivers%2fpulumi-dynatrace - Not found npm ERR! 404 
npm ERR! 404  '@pulumivers/pulumi-dynatrace@*' is not in this registry. npm ERR! 404 
npm ERR! 404 Note that you can also install from a npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in: .npm/_logs/2024-06-05T09_13_49_235Z-debug-0.log
```