### PR TITLE
fix(ci): fix NuGet publish step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ env:
   PROVIDER: dynatrace
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
+  NUGET_FEED_URL: https://api.nuget.org/v3/index.json
+  NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
   PULUMI_TEST_OWNER: "pulumiverse"
   PUBLISH_PYPI: true
   PUBLISH_NPM: true
@@ -16,262 +18,257 @@ jobs:
     needs: prerequisites
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v7
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v7
-      with:
-        path: ci-scripts
-        repository: jaxxstorm/scripts
-        ref: third_party
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v6
-      with:
-        go-version: ${{matrix.goversion}}
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v3.0.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v7
-      with:
-        pulumi-version: latest
-    - name: Setup Node
-      uses: actions/setup-node@v6
-      with:
-        node-version: ${{matrix.nodeversion}}
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: ${{matrix.dotnetversion}}
-    - name: Setup Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{matrix.pythonversion}}
-    - name: Download provider + tfgen binaries
-      uses: actions/download-artifact@v8
-      with:
-        name: ${{ env.PROVIDER }}-provider.tar.gz
-        path: ${{ github.workspace }}/bin
-    - name: Untar provider binaries
-      run: |-
-        tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
-        find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
-    - name: Install plugins
-      run: make install_plugins
-    - name: Update path
-      run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
-    - name: Build SDK
-      run: make build_${{ matrix.language }}
-    - name: Check worktree clean
-      run: ./ci-scripts/ci/check-worktree-is-clean
-    - name: Compress SDK folder
-      run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }}
-        .
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v7
-      with:
-        name: ${{ matrix.language  }}-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+      - name: Checkout Repo
+        uses: actions/checkout@v7
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v7
+        with:
+          path: ci-scripts
+          repository: jaxxstorm/scripts
+          ref: third_party
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{matrix.goversion}}
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v3.0.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v7
+        with:
+          pulumi-version: latest
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{matrix.nodeversion}}
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{matrix.dotnetversion}}
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{matrix.pythonversion}}
+      - name: Download provider + tfgen binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.PROVIDER }}-provider.tar.gz
+          path: ${{ github.workspace }}/bin
+      - name: Untar provider binaries
+        run: |-
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
+      - name: Install plugins
+        run: make install_plugins
+      - name: Update path
+        run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+      - name: Build SDK
+        run: make build_${{ matrix.language }}
+      - name: Check worktree clean
+        run: ./ci-scripts/ci/check-worktree-is-clean
+      - name: Compress SDK folder
+        run:
+          tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }}
+          .
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.language  }}-sdk.tar.gz
+          path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
     strategy:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 10.0.201
+          - 10.0.201
         goversion:
-        - 1.26.x
+          - 1.26.x
         language:
-        - nodejs
-        - python
-        - dotnet
-        - go
+          - nodejs
+          - python
+          - dotnet
+          - go
         nodeversion:
-        - 24.x
+          - 24.x
         pythonversion:
-        - "3.11"
+          - "3.11"
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v7
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v7
-      with:
-        path: ci-scripts
-        repository: jaxxstorm/scripts
-        ref: third_party
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v6
-      with:
-        go-version: ${{matrix.goversion}}
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v3.0.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v7
-      with:
-        pulumi-version: latest
-    - if: github.event_name == 'pull_request'
-      name: Install Schema Tools
-      uses: jaxxstorm/action-install-gh-release@v3.0.0
-      with:
-        repo: mikhailshilkov/schema-tools
-    - name: Build tfgen & provider binaries
-      run: make provider
-    # - if: github.event_name == 'pull_request'
-    #   name: Check Schema is Valid
-    #   run: |-
-    #     echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
-    #     schema-tools compare ${{ env.PROVIDER }} master --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
-    #     echo 'EOF' >> $GITHUB_ENV
-    # - if: github.event_name == 'pull_request'
-    #   name: Comment on PR with Details of Schema Check
-    #   uses: thollander/actions-comment-pull-request@1.0.1
-    #   with:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #     message: |
-    #       ### Does the PR have any schema changes?
+      - name: Checkout Repo
+        uses: actions/checkout@v7
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v7
+        with:
+          path: ci-scripts
+          repository: jaxxstorm/scripts
+          ref: third_party
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{matrix.goversion}}
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v3.0.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v7
+        with:
+          pulumi-version: latest
+      - if: github.event_name == 'pull_request'
+        name: Install Schema Tools
+        uses: jaxxstorm/action-install-gh-release@v3.0.0
+        with:
+          repo: mikhailshilkov/schema-tools
+      - name: Build tfgen & provider binaries
+        run: make provider
+      # - if: github.event_name == 'pull_request'
+      #   name: Check Schema is Valid
+      #   run: |-
+      #     echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
+      #     schema-tools compare ${{ env.PROVIDER }} master --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+      #     echo 'EOF' >> $GITHUB_ENV
+      # - if: github.event_name == 'pull_request'
+      #   name: Comment on PR with Details of Schema Check
+      #   uses: thollander/actions-comment-pull-request@1.0.1
+      #   with:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     message: |
+      #       ### Does the PR have any schema changes?
 
-    #       ${{ env.SCHEMA_CHANGES }}
-    - name: Tar provider binaries
-      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
-        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
-        }}
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v7
-      with:
-        name: ${{ env.PROVIDER }}-provider.tar.gz
-        path: ${{ github.workspace }}/bin/provider.tar.gz
+      #       ${{ env.SCHEMA_CHANGES }}
+      - name: Tar provider binaries
+        run:
+          tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
+          }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
+          }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.PROVIDER }}-provider.tar.gz
+          path: ${{ github.workspace }}/bin/provider.tar.gz
     strategy:
       fail-fast: true
       matrix:
         dotnetversion:
-        - 10.0.201
+          - 10.0.201
         goversion:
-        - 1.26.x
+          - 1.26.x
         nodeversion:
-        - 24.x
+          - 24.x
         pythonversion:
-        - "3.11"
+          - "3.11"
   publish:
     name: publish
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v7
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v6
-      with:
-        go-version: 1.26.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v3.0.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v7
-      with:
-        pulumi-version: latest
-    - name: Set Release Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)" >> $GITHUB_ENV
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v7
-      with:
-        args: release --clean --timeout 60m0s
-        version: "latest"
+      - name: Checkout Repo
+        uses: actions/checkout@v7
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.26.x
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v3.0.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v7
+        with:
+          pulumi-version: latest
+      - name: Set Release Version
+        run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)" >> $GITHUB_ENV
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          args: release --clean --timeout 60m0s
+          version: "latest"
   publish_sdk:
     name: publish_sdk
     needs: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v7
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v7
-      with:
-        path: ci-scripts
-        repository: jaxxstorm/scripts
-        ref: third_party
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v6
-      with:
-        go-version: ${{matrix.goversion}}
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v3.0.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v7
-      with:
-        pulumi-version: latest
-    - name: Setup Node
-      uses: actions/setup-node@v6
-      with:
-        node-version: ${{matrix.nodeversion}}
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: ${{matrix.dotnetversion}}
-    - name: Setup Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{matrix.pythonversion}}
-    - name: Download python SDK
-      uses: actions/download-artifact@v8
-      with:
-        name: python-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C ${{github.workspace}}/sdk/python
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v8
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C ${{github.workspace}}/sdk/dotnet
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v8
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C ${{github.workspace}}/sdk/nodejs
-    - run: python -m pip install pip twine
-    # - env:
-    #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    #   name: Publish SDKs
-    #   run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-    - if: ${{ matrix.language == 'python' && env.PUBLISH_PYPI == 'true' }}
-      name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.14.0
-      with:
-        packages_dir: ${{github.workspace}}/sdk/python/bin/dist
-    - if: ${{ matrix.language == 'nodejs' && env.PUBLISH_NPM == 'true' }}
-      name: Publish NPM package
-      run: npm publish --access public
-      working-directory: ${{github.workspace}}/sdk/nodejs
-    - if: ${{ matrix.language == 'dotnet' && env.PUBLISH_NUGET == 'true' }}
-      name: Login to Nuget
-      uses: NuGet/login@v1
-      id: login
-      with: 
-        user: pierspulumi
-    - if: ${{ matrix.language == 'dotnet' && env.PUBLISH_NUGET == 'true' }}
-      name: Publish Nuget package
-      env: 
-        NUGET_PUBLISH_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
-      run: find "${{github.workspace}}/sdk/dotnet/bin/Debug/" -name 'PiersKarsenbarg.*.nupkg' -exec dotnet nuget push -k "${NUGET_PUBLISH_KEY}" -s https://api.nuget.org/v3/index.json {} ';'
+      - name: Checkout Repo
+        uses: actions/checkout@v7
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v7
+        with:
+          path: ci-scripts
+          repository: jaxxstorm/scripts
+          ref: third_party
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{matrix.goversion}}
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v3.0.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v7
+        with:
+          pulumi-version: latest
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{matrix.nodeversion}}
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{matrix.dotnetversion}}
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{matrix.pythonversion}}
+      - name: Download python SDK
+        uses: actions/download-artifact@v8
+        with:
+          name: python-sdk.tar.gz
+          path: ${{ github.workspace}}/sdk/
+      - name: Uncompress python SDK
+        run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C ${{github.workspace}}/sdk/python
+      - name: Download dotnet SDK
+        uses: actions/download-artifact@v8
+        with:
+          name: dotnet-sdk.tar.gz
+          path: ${{ github.workspace}}/sdk/
+      - name: Uncompress dotnet SDK
+        run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C ${{github.workspace}}/sdk/dotnet
+      - name: Download nodejs SDK
+        uses: actions/download-artifact@v8
+        with:
+          name: nodejs-sdk.tar.gz
+          path: ${{ github.workspace}}/sdk/
+      - name: Uncompress nodejs SDK
+        run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C ${{github.workspace}}/sdk/nodejs
+      - run: python -m pip install pip twine
+      # - env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      #   name: Publish SDKs
+      #   run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      - if: ${{ matrix.language == 'python' && env.PUBLISH_PYPI == 'true' }}
+        name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.14.0
+        with:
+          packages-dir: ${{github.workspace}}/sdk/python/bin/dist
+      - if: ${{ matrix.language == 'nodejs' && env.PUBLISH_NPM == 'true' }}
+        name: Publish NPM package
+        run: npm publish --access public
+        working-directory: ${{github.workspace}}/sdk/nodejs
+      - if: ${{ matrix.language == 'dotnet' && env.PUBLISH_NUGET == 'true' }}
+        name: publish nuget package
+        run: |
+          dotnet nuget push ${{github.workspace}}/sdk/dotnet/bin/Debug/*.nupkg -s ${{ env.NUGET_FEED_URL }} -k ${{ env.NUGET_PUBLISH_KEY }}
     strategy:
       fail-fast: true
       matrix:
@@ -293,69 +290,70 @@ jobs:
     needs: build_sdk
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v7
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v7
-      with:
-        path: ci-scripts
-        repository: jaxxstorm/scripts
-        ref: third_party
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-    - name: Install Go
-      uses: actions/setup-go@v6
-      with:
-        go-version: ${{matrix.goversion}}
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v3.0.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/actions@v7
-      with:
-        pulumi-version: latest
-    - name: Setup Node
-      uses: actions/setup-node@v6
-      with:
-        node-version: ${{matrix.nodeversion}}
-        registry-url: https://registry.npmjs.org
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: ${{matrix.dotnetversion}}
-    - name: Setup Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{matrix.pythonversion}}
-    - name: Download provider + tfgen binaries
-      uses: actions/download-artifact@v8
-      with:
-        name: ${{ env.PROVIDER }}-provider.tar.gz
-        path: ${{ github.workspace }}/bin
-    - name: Untar provider binaries
-      run: |-
-        tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
-        find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
-    - run: dotnet nuget add source ${{ github.workspace }}/nuget
-    - name: Download SDK
-      uses: actions/download-artifact@v8
-      with:
-        name: ${{ matrix.language }}-sdk.tar.gz
-        path: ${{ github.workspace}}/sdk/
-    - name: Uncompress SDK folder
-      run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{
-        github.workspace }}/sdk/${{ matrix.language }}
-    - name: Update path
-      run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
-    - name: Install Python deps
-      run: |-
-        pip3 install virtualenv==20.0.23
-        pip3 install pipenv
-    - name: Install dependencies
-      run: make install_${{ matrix.language}}_sdk
-    - name: Run tests
-      run: cd examples && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language}} -parallel 4 .
+      - name: Checkout Repo
+        uses: actions/checkout@v7
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v7
+        with:
+          path: ci-scripts
+          repository: jaxxstorm/scripts
+          ref: third_party
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{matrix.goversion}}
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v3.0.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v7
+        with:
+          pulumi-version: latest
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{matrix.nodeversion}}
+          registry-url: https://registry.npmjs.org
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{matrix.dotnetversion}}
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{matrix.pythonversion}}
+      - name: Download provider + tfgen binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.PROVIDER }}-provider.tar.gz
+          path: ${{ github.workspace }}/bin
+      - name: Untar provider binaries
+        run: |-
+          tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
+          find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
+      - run: dotnet nuget add source ${{ github.workspace }}/nuget
+      - name: Download SDK
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.language }}-sdk.tar.gz
+          path: ${{ github.workspace}}/sdk/
+      - name: Uncompress SDK folder
+        run:
+          tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{
+          github.workspace }}/sdk/${{ matrix.language }}
+      - name: Update path
+        run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+      - name: Install Python deps
+        run: |-
+          pip3 install virtualenv==20.0.23
+          pip3 install pipenv
+      - name: Install dependencies
+        run: make install_${{ matrix.language}}_sdk
+      - name: Run tests
+        run: cd examples && go test -v -count=1 -cover -timeout 2h -tags=${{ matrix.language}} -parallel 4 .
     strategy:
       fail-fast: true
       matrix:
@@ -376,5 +374,5 @@ name: release
 "on":
   push:
     tags:
-    - v*.*.*
-    - '!v*.*.*-**'
+      - v*.*.*
+      - "!v*.*.*-**"

--- a/sdk/python/pulumiverse_dynatrace/policy_bindings.py
+++ b/sdk/python/pulumiverse_dynatrace/policy_bindings.py
@@ -241,7 +241,6 @@ class PolicyBindings(pulumi.CustomResource):
         # policies = [dynatrace_policy.cluster_policy.id, dynatrace_policy.env_policy.id] # INVALID, because `dynatrace_policy.env_policy` is not defined for the cluster level
         # }
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] cluster: The UUID of the cluster. The attribute `policies` must contain ONLY policies defined for that cluster.
@@ -324,7 +323,6 @@ class PolicyBindings(pulumi.CustomResource):
         # cluster  = "########-####-####-####-############"
         # policies = [dynatrace_policy.cluster_policy.id, dynatrace_policy.env_policy.id] # INVALID, because `dynatrace_policy.env_policy` is not defined for the cluster level
         # }
-
 
         :param str resource_name: The name of the resource.
         :param PolicyBindingsArgs args: The arguments to use to populate this resource's properties.


### PR DESCRIPTION
## Summary

Fixes the NuGet package publishing step in the release workflow by replacing the deprecated `NuGet/login` action with a direct `dotnet nuget push` command using repository-level env vars.

## Changes

- Add `NUGET_FEED_URL` and `NUGET_PUBLISH_KEY` as top-level workflow env vars (sourced from secrets)
- Replace `NuGet/login@v1` action with `dotnet nuget push` directly, simplifying the publish step
- Fix `packages_dir` → `packages-dir` parameter name in the PyPI publish action
- Reformat YAML indentation throughout for consistency

## Test Plan

- [ ] Trigger a release and verify NuGet package is published successfully
- [ ] Verify PyPI and NPM publish steps are unaffected