### PR TITLE
fix(ci): remove stray registry-url from release test job's Setup Node step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,7 +316,6 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: ${{matrix.nodeversion}}
-          registry-url: https://registry.npmjs.org
       - name: Setup DotNet
         uses: actions/setup-dotnet@v6
         with:


### PR DESCRIPTION
## Summary
- The `test` job's Setup Node step in `release.yml` still passed `registry-url: https://registry.npmjs.org`, left over from before `NODE_AUTH_TOKEN` was removed as an "unused" workflow-level env var in d878d9f34.
- With `registry-url` set but no `NODE_AUTH_TOKEN` anywhere in the workflow, `actions/setup-node` writes an `.npmrc` referencing `${NODE_AUTH_TOKEN}`, which `yarn link` fails to resolve during `make install_nodejs_sdk`, breaking the `test (nodejs)` job on release runs (e.g. https://github.com/pulumiverse/pulumi-dynatrace/actions/runs/31789839846/job/94737286816).
- The `test` job doesn't publish anything, so it doesn't need `registry-url` at all — removing it matches what was already done for the `build_sdk` job in the same cleanup commit.

## Test plan
- [ ] Push a release tag (or re-run a release workflow) and confirm the `test (nodejs)` job's `Install dependencies` step succeeds