### PR TITLE
fix(ci): use a modern gh-action-pypi-publish version for PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,7 +261,7 @@ jobs:
       #   run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       - if: ${{ matrix.language == 'python' && env.PUBLISH_PYPI == 'true' }}
         name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.10
+        uses: pypa/gh-action-pypi-publish@v1.14.1
         with:
           user: ${{ env.PYPI_USERNAME }}
           password: ${{ env.PYPI_PASSWORD }}


### PR DESCRIPTION
## Summary
- #343 downgraded `pypa/gh-action-pypi-publish` from `v1.14.1` to `v1.8.10` to restore `user`/`password` auth, but `v1.8.10` bundles an outdated `pkginfo`/`twine` that can't parse the `Metadata-Version` emitted by current `setuptools` when building the sdist (`make build_python` / `python3 setup.py build sdist`).
- This caused the PyPI publish step to fail with `InvalidDistribution: Metadata is missing required fields: Name, Version` on an otherwise valid package (e.g. https://github.com/pulumiverse/pulumi-dynatrace/actions/runs/31819086891/job/94835937864#step:19:39).
- `v1.14.1` still supports the same `user`/`password` inputs, so bumping the version back keeps the auth fix from #343 while fixing metadata parsing.

## Test plan
- [ ] Push a release tag and confirm the `Publish package to PyPI` step succeeds